### PR TITLE
Resolved validation error with CustomFieldFieldType enum.

### DIFF
--- a/src/KayakoRestAPI/Core/Constants/CustomFieldFieldType.cs
+++ b/src/KayakoRestAPI/Core/Constants/CustomFieldFieldType.cs
@@ -31,10 +31,10 @@ namespace KayakoRestApi.Core.Constants
 		[XmlEnum(Name = "9")]
 		LinkedSelectFields,
 
-		[XmlEnum(Name = "1")]
+		[XmlEnum(Name = "10")]
 		Date,
 
-		[XmlEnum(Name = "1")]
+		[XmlEnum(Name = "11")]
 		File
 	}
 }


### PR DESCRIPTION
Resolved the following error when calling KayakoClient.CustomFields.GetCustomFields()

```
System.InvalidOperationException was unhandled by user code
  HResult=-2146233079
  Message=There is an error in XML document (13, 77).
  Source=System.Xml
  StackTrace:
       at System.Xml.Serialization.XmlSerializer.Deserialize(XmlReader xmlReader, String encodingStyle, XmlDeserializationEvents events)
       at System.Xml.Serialization.XmlSerializer.Deserialize(TextReader textReader)
       at KayakoRestApi.Net.KayakoApiRequest.ProcessWebRequest[TTarget](WebRequest request) in C:\Source\KayakoRestAPI\Net\KayakoApiRequest.cs:line 230
       at KayakoRestApi.Net.KayakoApiRequest.ExecuteCall[TTarget](String apiMethod, String parameters, HttpMethod httpMethod) in C:\Source\KayakoRestAPI\Net\KayakoApiRequest.cs:line 208
       at KayakoRestApi.Net.KayakoApiRequest.ExecuteGet[TTarget](String apiMethod) in C:\Source\KayakoRestAPI\Net\KayakoApiRequest.cs:line 101
       at KayakoRestApi.Controllers.CustomFieldController.GetCustomFields() in C:\Source\KayakoRestAPI\Controllers\CustomFieldController.cs:line 39
       at UserCenter.Controllers.SupportController.Ticket(Int32 id) in C:\Source\UserCenter\Controllers\SupportController.cs:line 108
       at lambda_method(Closure , ControllerBase , Object[] )
       at System.Web.Mvc.ActionMethodDispatcher.Execute(ControllerBase controller, Object[] parameters)
       at System.Web.Mvc.ReflectedActionDescriptor.Execute(ControllerContext controllerContext, IDictionary`2 parameters)
       at System.Web.Mvc.ControllerActionInvoker.InvokeActionMethod(ControllerContext controllerContext, ActionDescriptor actionDescriptor, IDictionary`2 parameters)
       at System.Web.Mvc.Async.AsyncControllerActionInvoker.ActionInvocation.InvokeSynchronousActionMethod()
       at System.Web.Mvc.Async.AsyncControllerActionInvoker.<BeginInvokeSynchronousActionMethod>b__39(IAsyncResult asyncResult, ActionInvocation innerInvokeState)
       at System.Web.Mvc.Async.AsyncResultWrapper.WrappedAsyncResult`2.CallEndDelegate(IAsyncResult asyncResult)
       at System.Web.Mvc.Async.AsyncResultWrapper.WrappedAsyncResultBase`1.End()
       at System.Web.Mvc.Async.AsyncResultWrapper.End[TResult](IAsyncResult asyncResult, Object tag)
       at System.Web.Mvc.Async.AsyncControllerActionInvoker.EndInvokeActionMethod(IAsyncResult asyncResult)
       at System.Web.Mvc.Async.AsyncControllerActionInvoker.AsyncInvocationWithFilters.<InvokeActionMethodFilterAsynchronouslyRecursive>b__3d()
       at System.Web.Mvc.Async.AsyncControllerActionInvoker.AsyncInvocationWithFilters.<>c__DisplayClass46.<InvokeActionMethodFilterAsynchronouslyRecursive>b__3f()
  InnerException: 
       HResult=-2146233079
       Message=Instance validation error: '11' is not a valid value for CustomFieldFieldType.
       Source=Microsoft.GeneratedCode
       StackTrace:
            at Microsoft.Xml.Serialization.GeneratedAssembly.XmlSerializationReaderCustomFieldCollection.Read1_CustomFieldFieldType(String s)
            at Microsoft.Xml.Serialization.GeneratedAssembly.XmlSerializationReaderCustomFieldCollection.Read3_CustomField(Boolean isNullable, Boolean checkType)
            at Microsoft.Xml.Serialization.GeneratedAssembly.XmlSerializationReaderCustomFieldCollection.Read4_customfields()
       InnerException: 
```
